### PR TITLE
Use __originalEvent if available

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -2,5 +2,7 @@ export function normalizeEvent(e) {
   if (e instanceof Event) {
     return e;
   }
-  return e.originalEvent;
+  // __originalEvent is a private escape hatch of Ember's EventDispatcher to allow accessing `originalEvent` without
+  // triggering a deprecation message.
+  return e.__originalEvent || e.originalEvent;
 }

--- a/tests/unit/normalize-event-test.js
+++ b/tests/unit/normalize-event-test.js
@@ -9,6 +9,14 @@ module('normalize-event', function() {
     assert.equal(e, normalizeEvent(jQueryEvent));
   });
 
+  test('it extracts the native event from jQuery events, using __originalEvent if available', function(assert) {
+    let e = new MouseEvent("click");
+    let __e = new MouseEvent("click");
+    let jQueryEvent = $.Event(e);
+    jQueryEvent.__originalEvent = __e;
+    assert.equal(__e, normalizeEvent(jQueryEvent));
+  });
+
   test('it returns the passed-in event if it is native', function(assert) {
     let e = new MouseEvent('click');
     assert.equal(e, normalizeEvent(e));


### PR DESCRIPTION
Provided by the `Proxy`-ied jQuery.Event to access the native event without triggering a deprecation. 

See https://github.com/emberjs/ember.js/pull/16690